### PR TITLE
Fixed two bugs with Event model. 

### DIFF
--- a/models/Event.js
+++ b/models/Event.js
@@ -1,6 +1,21 @@
 // Import mongoose
 const mongoose = require("mongoose");
 
+// This schema is only used as a subdocument for Events, so it will just be defined here and not exported
+var InviteeSchema = new mongoose.Schema({
+    member: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Member',
+        required: true
+    },
+    status: {
+        type: String,
+        enum: ['claimed', 'declined', 'invited'],
+        required: true
+    },
+});
+
+// Main event schema defenition. This will be exported with Invitees as subdocuments.
 var EventSchema = new mongoose.Schema({
     // Title (Text)
     title: {
@@ -58,17 +73,3 @@ const Event = mongoose.model('Event', EventSchema);
 
 // Export model
 module.exports = Event;
-
-
-// This schema is only used as a subdocument for Events, so it will just be defined here and not exported
-var InviteeSchema = new mongoose.Schema({
-    member: {
-        type: ObjectId,
-        required: true
-    },
-    status: {
-        type: String,
-        enum: ['claimed', 'declined', 'invited'],
-        required: true
-    },
-});


### PR DESCRIPTION
InviteeSchema was called before assignment and referenced the mongoose ObjectId class improperly. Both issues are fixed in the PR.

This PR only changes Event.js in the models folder.

This PR firstly moves a chunk of code defining the InviteeSchema above the definition of the EventSchema, since EventSchema references InviteeSchema. The only other changes is setting the `type` to `mongoose.Schema.Types.ObjectId` as opposed to simply `ObjectId` which doesn't work, and then adding `ref: 'Member'` so that the Mongoose actually knows what the objectId is supposed to be referring to. 